### PR TITLE
Updates in the README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,6 +341,50 @@ You can decode custom types the same way, as long as the type also conforms to
 
 For more examples on how to use Argo, please check out the tests.
 
+### Known Issues
+
+You can encounter with issue like this [one](https://github.com/thoughtbot/Argo/issues/184). 
+Due to limitations in the Swift compiler it can't handle more than 12 clauses in one expression.
+For instance, if you have a model with more than 12 fields you should consider breaking it into smaller submodels. Or (if this is not possible) as a workaround you have to split mapping into two (or more) subexpressions. Also you need to have _ before all the parameter names after the break in the curried `create` function.
+Example:
+
+```swift
+static func create
+        (alreadyFollowed: Bool)
+        (alreadyLived: Bool)
+        (alreadyWanted: Bool)
+        (langBarrier: Bool)
+        (followedBy: Int)
+        (index: Int)
+        (lived: Int)
+        (_ wanted: Int)
+        (_ livedOutOfCriteria: Int)
+        (_ storiesOutOfCriteria: Int)
+        (_ stories: [Story])
+        (_ nextStories: [Story])
+        (_ previousStories: [Story]) -> StoryStat {...}
+        
+  static func decode(j: JSON) -> Decoded<StoryStat> {
+        //Break the expression with more than 12 clauses into two parts: 
+        let parseExpression = StoryStat.create
+            <^> j <| "alreadyFollowed"
+            <*> j <| "alreadyLived"
+            <*> j <| "alreadyWanted"
+            <*> j <| "langBarriere"
+            <*> j <| "followedBy"
+            <*> j <| "index"
+            <*> j <| "lived"
+
+         return parseExpression
+            <*> j <| "wanted"
+            <*> j <| "livedOutOfCriteria"
+            <*> j <| "storiesOutOfCriteria"
+            <*> j <|| "stories"
+            <*> j <|| "nextStories"
+            <*> j <|| "previousStories"
+    }
+  ```
+
 Contributing
 ------------
 


### PR DESCRIPTION
Added info and workaround in the "Known Issues: section of the README.md file about the issue with Swift compiler:  "Expression was too complex to be solved in reasonable time; consider breaking up into distinct sub-expressions".
Workaround was suggested in this issue discussion (https://github.com/thoughtbot/Argo/issues/5)